### PR TITLE
Replaced shebangs with the preferred for portability

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -xe
 rm -rf ./build/

--- a/install-autodetect.sh
+++ b/install-autodetect.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # What does this script ?
 #

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # What does this script ?
 #

--- a/print_icons.sh
+++ b/print_icons.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 YELLOW='\033[1;33m'
 GREEN='\033[0;32m'

--- a/scripts/colors.sh
+++ b/scripts/colors.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 NORMAL='\033[0m'
 RED='\033[00;31m'

--- a/scripts/detect_font_terminal/find_font_console.sh
+++ b/scripts/detect_font_terminal/find_font_console.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #Useless, consoles don't support font fallback
 

--- a/scripts/detect_font_terminal/find_font_gnometerminal.sh
+++ b/scripts/detect_font_terminal/find_font_gnometerminal.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BASEDIR=$(dirname `readlink -f "$0"`)
 source ${BASEDIR}/../colors.sh

--- a/scripts/detect_font_terminal/find_font_system.sh
+++ b/scripts/detect_font_terminal/find_font_system.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 gsettings get org.gnome.desktop.interface monospace-font-name | sed -e "s/^'//" -e "s/'\$//" | rev | cut -d ' ' -f 2- | rev

--- a/scripts/detect_font_terminal/find_font_terminator.sh
+++ b/scripts/detect_font_terminal/find_font_terminator.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 BASEDIR=$(dirname `readlink -f "$0"`)
 source ${BASEDIR}/../colors.sh

--- a/scripts/generate_fontconfig.sh
+++ b/scripts/generate_fontconfig.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Generate a fontconfig configuration file
 # See /etc/fonts/conf.d/README

--- a/scripts/generate_fontconfig_autodetect.sh
+++ b/scripts/generate_fontconfig_autodetect.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Generate a fontconfig configuration file
 # See /etc/fonts/conf.d/README

--- a/scripts/inte_bash.sh
+++ b/scripts/inte_bash.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 YELLOW='\033[1;33m'
 GREEN='\033[0;32m'

--- a/scripts/inte_bash_export.sh
+++ b/scripts/inte_bash_export.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 YELLOW='\033[1;33m'
 GREEN='\033[0;32m'

--- a/scripts/inte_c_header.sh
+++ b/scripts/inte_c_header.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 YELLOW='\033[1;33m'
 GREEN='\033[0;32m'

--- a/scripts/inte_emacs.sh
+++ b/scripts/inte_emacs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 YELLOW='\033[1;33m'
 GREEN='\033[0;32m'

--- a/scripts/inte_fish.sh
+++ b/scripts/inte_fish.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 YELLOW='\033[1;33m'
 GREEN='\033[0;32m'

--- a/scripts/inte_without_codepoint.sh
+++ b/scripts/inte_without_codepoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 YELLOW='\033[1;33m'
 GREEN='\033[0;32m'


### PR DESCRIPTION
On Ubuntu 16.04, running `print_icons.sh` after installing resulted in:

`bash: ./print_icons.sh: /usr/bin/bash: bad interpreter: No such file or directory`

The preferred [shebang for portability](https://en.wikipedia.org/wiki/Shebang_%28Unix%29#Portability) is `#!/usr/bin/env bash`. This PR changes most of the shebangs to that preferred method.

Tested on Ubuntu 16.04. 