### PR TITLE
Use more conventional Emacs library header

### DIFF
--- a/build/icons-in-terminal.el
+++ b/build/icons-in-terminal.el
@@ -1,3 +1,32 @@
+;;; icons-in-terminal.el --- Use any font without replacing or patching your font
+
+;; Copyright (C) 2017 Sebastien Chapuis
+
+;; Author: Sebastien Chapuis <sebastien@chapu.is>
+;; Homepage: https://github.com/sebastiencs/icons-in-terminal
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program; see the file COPYING.  If not, write to
+;; the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+;; Floor, Boston, MA 02110-1301, USA.
+
+;;; Commentary:
+
+;; Icons-in-terminal allows you to get any fonts in your Emacs without
+;; replacing or patching your font.
+
+;;; Code:
+
 (require 'font-lock+)
 
 (defconst icons-in-terminal-alist


### PR DESCRIPTION
Doing makes some automated metadata extraction possible,
e.g. for the benefit of the Emacsmirror or Melpa.