### PR TITLE
Use XMLStarlet to properly escape font names when generating a fontconfig file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ There are a few dependencies to install:
 
 - Python 3
 - [fontforge (with python extension)](https://fontforge.github.io)
+- [XMLStarlet](http://xmlstar.sourceforge.net/)
 
 You can add the name and path of your font to the file `config.json`.  
 Each font can take parameters:  

--- a/scripts/generate_fontconfig.sh
+++ b/scripts/generate_fontconfig.sh
@@ -14,7 +14,7 @@ echo "  <!-- <alias><family>YOUR_TERMINAL_FONT</family><default><family>icons-in
 
 while IFS='\n' read FONT_NAME;
 do
-    FONT_NAME=`echo $FONT_NAME | tr -d '\n'`
+    FONT_NAME=`echo $FONT_NAME | tr -d '\n' | xml esc`
     echo '  <alias><family>'"${FONT_NAME}"'</family><prefer><family>icons-in-terminal</family></prefer></alias>'
 #    echo '  <alias><family>'"${FONT_NAME}"'</family><prefer><family>icons-in-terminal</family></prefer><default><family>icons-in-terminal</family></default></alias>'
 done < <(fc-list :mono family | sort | sed "s/\\\-/-/g" | grep -v 'icons-in-terminal')


### PR DESCRIPTION
Or else some font names like "B&H LucidaTypewriter" will contain an invalid token and cause errors when parsing.